### PR TITLE
Fix an extra right parenthesis

### DIFF
--- a/scam/camera.scm
+++ b/scam/camera.scm
@@ -88,5 +88,4 @@
     (lambda (z0)
       (comp (lambda (x y z) (values (* (/ z0 z) x) (* (/ z0 z) y) z))
 	    <- a-vector->list))))
-)
 


### PR DESCRIPTION
In scam/camera.scm, there is an extra parenthesis.
